### PR TITLE
FIXED: correctly process backslash+space as in A vs.\ B.

### DIFF
--- a/latex.cmd
+++ b/latex.cmd
@@ -104,7 +104,7 @@
 \begin=begin		2 1
 \end{-}=end		1 2
 \\[d]			0 1
-\
+\ 
 \-
 \verb=verb
 \newline


### PR DESCRIPTION
I think this was accidentally removed in the previous patch. As a result, `make html` currently hangs. Please verify. Thank you!

P.S.: To avoid reintroducing this problem in future edits, can we rewrite this definition somehow so that the line does not end with whitespace that is important? Maybe `\ %` or similar syntax?